### PR TITLE
Add verify

### DIFF
--- a/src/aux-gui.sh
+++ b/src/aux-gui.sh
@@ -36,5 +36,5 @@ _EOF_
 }
 
 pango_raw(){
-    sed "s/</\&lt;/" | sed "s/>/\&gt;/"
+    sed -e "s/</\&lt;/" -e "s/>/\&gt;/"
 }

--- a/src/aux-gui.sh
+++ b/src/aux-gui.sh
@@ -34,3 +34,7 @@ key_info() {
 </tt></big>
 _EOF_
 }
+
+pango_raw(){
+    sed "s/</\&lt;/" | sed "s/>/\&gt;/"
+}

--- a/src/gui/main.sh
+++ b/src/gui/main.sh
@@ -2,7 +2,9 @@
 
 gui_main() {
     get_gpg_key
-    is_true $DEBUG || exec &>/dev/null    # ignore all output, unless debugging
+
+    local out
+    is_true $DEBUG && out='/dev/tty' || out='/dev/null'
     yad --title="EasyGnuPG" \
         --text="$(key_info $GPG_KEY)" \
         --selectable-labels \
@@ -16,7 +18,8 @@ gui_main() {
         --field="Manage Key":FBTN "bash -c 'gui key'" \
         --field="Manage Contacts":FBTN "bash -c 'gui contacts'" \
         --field="Settings":FBTN "bash -c 'gui settings'" \
-        --button=gtk-quit
+        --button=gtk-quit \
+        &> $out
 }
 
 #

--- a/src/gui/sign.sh
+++ b/src/gui/sign.sh
@@ -1,5 +1,5 @@
 gui_sign() {
-    local file output
+    local file output err
 
     file=$(yad --file --title="EasyGnuPG | Sign a File")
     [[ -n "$file" ]] || return 0
@@ -8,8 +8,10 @@ gui_sign() {
         rm -f "$file.signature"
     fi
 
-    output=$(call cmd_sign $file)
-    [[ -n "$output" ]] && message error "$output"
+    output=$(call cmd_sign $file 2>&1)
+    err=$?
+    is_true $DEBUG && echo "$output"
+    [[ $err == 0 ]] || message error "$output"
 
     if [[ -s "$file.signature" ]]; then
         yad --file --filename="$file.signature" &

--- a/src/gui/sign.sh
+++ b/src/gui/sign.sh
@@ -11,14 +11,13 @@ gui_sign() {
     output=$(call cmd_sign $file 2>&1)
     err=$?
     is_true $DEBUG && echo "$output"
-    [[ $err == 0 ]] || message error "$output"
 
-    if [[ -s "$file.signature" ]]; then
+    if [[ -s "$file.signature" ]] && [[ $err == 0 ]]; then
         yad --file --filename="$file.signature" &
         sleep 1
         message info "Signature saved as:\n <tt>$file.signature</tt>"
     else
-        message error "Failed to sign file."
+        message error "Failed to sign file.\n" "<tt>$(echo "$output" | grep '^gpg:' | uniq)</tt>"
     fi
 }
 

--- a/src/gui/verify.sh
+++ b/src/gui/verify.sh
@@ -1,16 +1,17 @@
 gui_verify() {
-    local file output
+    local file output err
+
     file=$(yad \
-            --file \
-            --title="EasyGnuPG | Verify Signature"\
-            --file-filter "Signature files | *.signature" \
-            ) || return 0
-    
+               --file \
+               --title="EasyGnuPG | Verify Signature"\
+               --file-filter="Signature files | *.signature" \
+        ) || return 0
+
     output=$(call cmd_verify "$file" 2>&1)
-    if is_true $DEBUG; then
-        echo "$output"
-    fi
-    message info "$(echo "$output" | grep "^gpg:" | pango_raw )"
+    err=$?
+
+    is_true $DEBUG && echo "$output"
+    message info "<tt>$(echo "$output" | grep '^gpg: ' | pango_raw )</tt>"
 }
 
 #

--- a/src/gui/verify.sh
+++ b/src/gui/verify.sh
@@ -1,0 +1,32 @@
+gui_verify() {
+    local file output
+    file=$(yad \
+            --file \
+            --title="EasyGnuPG | Verify Signature"\
+            --file-filter "Signature files | *.signature" \
+            ) || return 0
+    
+    output=$(call cmd_verify "$file" 2>&1)
+    if is_true $DEBUG; then
+        echo "$output"
+    fi
+    message info "$(echo "$output" | grep "^gpg:" | pango_raw )"
+}
+
+#
+# This file is part of EasyGnuPG.  EasyGnuPG is a wrapper around GnuPG
+# to simplify its operations.  Copyright (C) 2018 Dashamir Hoxha
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/
+#

--- a/src/gui/verify.sh
+++ b/src/gui/verify.sh
@@ -1,5 +1,5 @@
 gui_verify() {
-    local file output err
+    local file output err msg_type
 
     file=$(yad \
                --file \
@@ -9,9 +9,11 @@ gui_verify() {
 
     output=$(call cmd_verify "$file" 2>&1)
     err=$?
-
     is_true $DEBUG && echo "$output"
-    message info "<tt>$(echo "$output" | grep '^gpg: ' | pango_raw )</tt>"
+    [[ $err == 0 ]] && msg_type="info" || msg_type="error"
+
+    message $msg_type "<tt>$(echo "$output" | grep '^gpg:' | pango_raw)</tt>"
+    return $err
 }
 
 #


### PR DESCRIPTION
currently doesn't check if contact is in the list
added pango_raw function, it escapes stdin to make it behave like raw text in pango format. Currently it changes "<" ">" to "\&lt;" and "\&gt;".